### PR TITLE
Adds quotes and encoding to handle spaces in path directories

### DIFF
--- a/src/generators/__snapshots__/bashHelper.test.js.snap
+++ b/src/generators/__snapshots__/bashHelper.test.js.snap
@@ -5,12 +5,12 @@ exports[`creates 2nodes istanbul bash tessera cakeshop custom ports 1`] = `
 echo \\"
 Starting Quorum network...
 \\"
-BIN_GETH=/path/to/user/home/.quorum-wizard/bin/quorum/2.7.0/geth
-BIN_TESSERA=/path/to/user/home/.quorum-wizard/bin/tessera/0.10.6/tessera-app.jar
-BIN_CAKESHOP=/path/to/user/home/.quorum-wizard/bin/cakeshop/0.11.0/cakeshop.war
+BIN_GETH='/path/to/user/home/.quorum-wizard/bin/quorum/2.7.0/geth'
+BIN_TESSERA='/path/to/user/home/.quorum-wizard/bin/tessera/0.10.6/tessera-app.jar'
+BIN_CAKESHOP='/path/to/user/home/.quorum-wizard/bin/cakeshop/0.11.0/cakeshop.war'
 
-java  -Xms128M -Xmx128M -jar $BIN_TESSERA -configfile qdata/c1/tessera-config-09-1.json >> qdata/logs/tessera1.log 2>&1 &
-java  -Xms128M -Xmx128M -jar $BIN_TESSERA -configfile qdata/c2/tessera-config-09-2.json >> qdata/logs/tessera2.log 2>&1 &
+java  -Xms128M -Xmx128M -jar \\"$BIN_TESSERA\\" -configfile qdata/c1/tessera-config-09-1.json >> qdata/logs/tessera1.log 2>&1 &
+java  -Xms128M -Xmx128M -jar \\"$BIN_TESSERA\\" -configfile qdata/c2/tessera-config-09-2.json >> qdata/logs/tessera2.log 2>&1 &
 
 echo \\"Waiting until all Tessera nodes are running...\\"
 DOWN=true
@@ -52,10 +52,10 @@ done
 echo \\"All Tessera nodes started\\"
 
 echo \\"Starting Quorum nodes\\"
-PRIVATE_CONFIG=/current/working/dir/network/2-nodes-istanbul-tessera-bash/qdata/c1/tm.ipc nohup $BIN_GETH --datadir qdata/dd1 --nodiscover --rpc --rpccorsdomain=* --rpcvhosts=* --rpcaddr 0.0.0.0 --rpcapi admin,db,eth,debug,miner,net,shh,txpool,personal,web3,quorum,istanbul,quorumPermission --ws --wsaddr 0.0.0.0 --wsorigins=* --wsapi admin,db,eth,debug,miner,net,shh,txpool,personal,web3,quorum,istanbul,quorumPermission --emitcheckpoints --unlock 0 --password qdata/dd1/keystore/password.txt --allow-insecure-unlock --graphql --graphql.port 58000 --graphql.corsdomain=* --graphql.addr 0.0.0.0 --istanbul.blockperiod 5 --syncmode full --mine --minerthreads 1 --permissioned --verbosity 5 --networkid 10 --rpcport 56000 --wsport 57000 --port 55001 2>>qdata/logs/1.log &
-PRIVATE_CONFIG=/current/working/dir/network/2-nodes-istanbul-tessera-bash/qdata/c2/tm.ipc nohup $BIN_GETH --datadir qdata/dd2 --nodiscover --rpc --rpccorsdomain=* --rpcvhosts=* --rpcaddr 0.0.0.0 --rpcapi admin,db,eth,debug,miner,net,shh,txpool,personal,web3,quorum,istanbul,quorumPermission --ws --wsaddr 0.0.0.0 --wsorigins=* --wsapi admin,db,eth,debug,miner,net,shh,txpool,personal,web3,quorum,istanbul,quorumPermission --emitcheckpoints --unlock 0 --password qdata/dd2/keystore/password.txt --allow-insecure-unlock --graphql --graphql.port 58001 --graphql.corsdomain=* --graphql.addr 0.0.0.0 --istanbul.blockperiod 5 --syncmode full --mine --minerthreads 1 --permissioned --verbosity 5 --networkid 10 --rpcport 56001 --wsport 57001 --port 55001 2>>qdata/logs/2.log &
+PRIVATE_CONFIG='/current/working/dir/network/2-nodes-istanbul-tessera-bash/qdata/c1/tm.ipc' nohup \\"$BIN_GETH\\" --datadir qdata/dd1 --nodiscover --rpc --rpccorsdomain=* --rpcvhosts=* --rpcaddr 0.0.0.0 --rpcapi admin,db,eth,debug,miner,net,shh,txpool,personal,web3,quorum,istanbul,quorumPermission --ws --wsaddr 0.0.0.0 --wsorigins=* --wsapi admin,db,eth,debug,miner,net,shh,txpool,personal,web3,quorum,istanbul,quorumPermission --emitcheckpoints --unlock 0 --password qdata/dd1/keystore/password.txt --allow-insecure-unlock --graphql --graphql.port 58000 --graphql.corsdomain=* --graphql.addr 0.0.0.0 --istanbul.blockperiod 5 --syncmode full --mine --minerthreads 1 --permissioned --verbosity 5 --networkid 10 --rpcport 56000 --wsport 57000 --port 55001 2>>qdata/logs/1.log &
+PRIVATE_CONFIG='/current/working/dir/network/2-nodes-istanbul-tessera-bash/qdata/c2/tm.ipc' nohup \\"$BIN_GETH\\" --datadir qdata/dd2 --nodiscover --rpc --rpccorsdomain=* --rpcvhosts=* --rpcaddr 0.0.0.0 --rpcapi admin,db,eth,debug,miner,net,shh,txpool,personal,web3,quorum,istanbul,quorumPermission --ws --wsaddr 0.0.0.0 --wsorigins=* --wsapi admin,db,eth,debug,miner,net,shh,txpool,personal,web3,quorum,istanbul,quorumPermission --emitcheckpoints --unlock 0 --password qdata/dd2/keystore/password.txt --allow-insecure-unlock --graphql --graphql.port 58001 --graphql.corsdomain=* --graphql.addr 0.0.0.0 --istanbul.blockperiod 5 --syncmode full --mine --minerthreads 1 --permissioned --verbosity 5 --networkid 10 --rpcport 56001 --wsport 57001 --port 55001 2>>qdata/logs/2.log &
 echo \\"Starting Cakeshop\\"
-java -Dcakeshop.config.dir=qdata/cakeshop -Dlogging.path=qdata/logs/cakeshop -jar $BIN_CAKESHOP > /dev/null 2>&1 &
+java -Dcakeshop.config.dir=qdata/cakeshop -Dlogging.path=qdata/logs/cakeshop -jar \\"$BIN_CAKESHOP\\" > /dev/null 2>&1 &
 
   DOWN=true
   k=10
@@ -99,14 +99,14 @@ exports[`creates 3nodes raft bash no tessera 1`] = `
 echo \\"
 Starting Quorum network...
 \\"
-BIN_GETH=/path/to/user/home/.quorum-wizard/bin/quorum/2.7.0/geth
+BIN_GETH='/path/to/user/home/.quorum-wizard/bin/quorum/2.7.0/geth'
 
 
 
 echo \\"Starting Quorum nodes\\"
-PRIVATE_CONFIG=ignore nohup $BIN_GETH --datadir qdata/dd1 --nodiscover --rpc --rpccorsdomain=* --rpcvhosts=* --rpcaddr 0.0.0.0 --rpcapi admin,db,eth,debug,miner,net,shh,txpool,personal,web3,quorum,raft,quorumPermission --ws --wsaddr 0.0.0.0 --wsorigins=* --wsapi admin,db,eth,debug,miner,net,shh,txpool,personal,web3,quorum,raft,quorumPermission --emitcheckpoints --unlock 0 --password qdata/dd1/keystore/password.txt --allow-insecure-unlock --graphql --graphql.port 24000 --graphql.corsdomain=* --graphql.addr 0.0.0.0 --raft --raftport 50401 --permissioned --verbosity 5 --networkid 10 --rpcport 22000 --wsport 23000 --port 21000 2>>qdata/logs/1.log &
-PRIVATE_CONFIG=ignore nohup $BIN_GETH --datadir qdata/dd2 --nodiscover --rpc --rpccorsdomain=* --rpcvhosts=* --rpcaddr 0.0.0.0 --rpcapi admin,db,eth,debug,miner,net,shh,txpool,personal,web3,quorum,raft,quorumPermission --ws --wsaddr 0.0.0.0 --wsorigins=* --wsapi admin,db,eth,debug,miner,net,shh,txpool,personal,web3,quorum,raft,quorumPermission --emitcheckpoints --unlock 0 --password qdata/dd2/keystore/password.txt --allow-insecure-unlock --graphql --graphql.port 24001 --graphql.corsdomain=* --graphql.addr 0.0.0.0 --raft --raftport 50402 --permissioned --verbosity 5 --networkid 10 --rpcport 22001 --wsport 23001 --port 21001 2>>qdata/logs/2.log &
-PRIVATE_CONFIG=ignore nohup $BIN_GETH --datadir qdata/dd3 --nodiscover --rpc --rpccorsdomain=* --rpcvhosts=* --rpcaddr 0.0.0.0 --rpcapi admin,db,eth,debug,miner,net,shh,txpool,personal,web3,quorum,raft,quorumPermission --ws --wsaddr 0.0.0.0 --wsorigins=* --wsapi admin,db,eth,debug,miner,net,shh,txpool,personal,web3,quorum,raft,quorumPermission --emitcheckpoints --unlock 0 --password qdata/dd3/keystore/password.txt --allow-insecure-unlock --graphql --graphql.port 24002 --graphql.corsdomain=* --graphql.addr 0.0.0.0 --raft --raftport 50403 --permissioned --verbosity 5 --networkid 10 --rpcport 22002 --wsport 23002 --port 21002 2>>qdata/logs/3.log &
+PRIVATE_CONFIG='ignore' nohup \\"$BIN_GETH\\" --datadir qdata/dd1 --nodiscover --rpc --rpccorsdomain=* --rpcvhosts=* --rpcaddr 0.0.0.0 --rpcapi admin,db,eth,debug,miner,net,shh,txpool,personal,web3,quorum,raft,quorumPermission --ws --wsaddr 0.0.0.0 --wsorigins=* --wsapi admin,db,eth,debug,miner,net,shh,txpool,personal,web3,quorum,raft,quorumPermission --emitcheckpoints --unlock 0 --password qdata/dd1/keystore/password.txt --allow-insecure-unlock --graphql --graphql.port 24000 --graphql.corsdomain=* --graphql.addr 0.0.0.0 --raft --raftport 50401 --permissioned --verbosity 5 --networkid 10 --rpcport 22000 --wsport 23000 --port 21000 2>>qdata/logs/1.log &
+PRIVATE_CONFIG='ignore' nohup \\"$BIN_GETH\\" --datadir qdata/dd2 --nodiscover --rpc --rpccorsdomain=* --rpcvhosts=* --rpcaddr 0.0.0.0 --rpcapi admin,db,eth,debug,miner,net,shh,txpool,personal,web3,quorum,raft,quorumPermission --ws --wsaddr 0.0.0.0 --wsorigins=* --wsapi admin,db,eth,debug,miner,net,shh,txpool,personal,web3,quorum,raft,quorumPermission --emitcheckpoints --unlock 0 --password qdata/dd2/keystore/password.txt --allow-insecure-unlock --graphql --graphql.port 24001 --graphql.corsdomain=* --graphql.addr 0.0.0.0 --raft --raftport 50402 --permissioned --verbosity 5 --networkid 10 --rpcport 22001 --wsport 23001 --port 21001 2>>qdata/logs/2.log &
+PRIVATE_CONFIG='ignore' nohup \\"$BIN_GETH\\" --datadir qdata/dd3 --nodiscover --rpc --rpccorsdomain=* --rpcvhosts=* --rpcaddr 0.0.0.0 --rpcapi admin,db,eth,debug,miner,net,shh,txpool,personal,web3,quorum,raft,quorumPermission --ws --wsaddr 0.0.0.0 --wsorigins=* --wsapi admin,db,eth,debug,miner,net,shh,txpool,personal,web3,quorum,raft,quorumPermission --emitcheckpoints --unlock 0 --password qdata/dd3/keystore/password.txt --allow-insecure-unlock --graphql --graphql.port 24002 --graphql.corsdomain=* --graphql.addr 0.0.0.0 --raft --raftport 50403 --permissioned --verbosity 5 --networkid 10 --rpcport 22002 --wsport 23002 --port 21002 2>>qdata/logs/3.log &
 
 echo \\"Successfully started Quorum network.\\"
 echo \\"\\""
@@ -117,12 +117,12 @@ exports[`creates 3nodes raft bash tessera 1`] = `
 echo \\"
 Starting Quorum network...
 \\"
-BIN_GETH=/path/to/user/home/.quorum-wizard/bin/quorum/2.7.0/geth
-BIN_TESSERA=/path/to/user/home/.quorum-wizard/bin/tessera/0.10.6/tessera-app.jar
+BIN_GETH='/path/to/user/home/.quorum-wizard/bin/quorum/2.7.0/geth'
+BIN_TESSERA='/path/to/user/home/.quorum-wizard/bin/tessera/0.10.6/tessera-app.jar'
 
-java  -Xms128M -Xmx128M -jar $BIN_TESSERA -configfile qdata/c1/tessera-config-09-1.json >> qdata/logs/tessera1.log 2>&1 &
-java  -Xms128M -Xmx128M -jar $BIN_TESSERA -configfile qdata/c2/tessera-config-09-2.json >> qdata/logs/tessera2.log 2>&1 &
-java  -Xms128M -Xmx128M -jar $BIN_TESSERA -configfile qdata/c3/tessera-config-09-3.json >> qdata/logs/tessera3.log 2>&1 &
+java  -Xms128M -Xmx128M -jar \\"$BIN_TESSERA\\" -configfile qdata/c1/tessera-config-09-1.json >> qdata/logs/tessera1.log 2>&1 &
+java  -Xms128M -Xmx128M -jar \\"$BIN_TESSERA\\" -configfile qdata/c2/tessera-config-09-2.json >> qdata/logs/tessera2.log 2>&1 &
+java  -Xms128M -Xmx128M -jar \\"$BIN_TESSERA\\" -configfile qdata/c3/tessera-config-09-3.json >> qdata/logs/tessera3.log 2>&1 &
 
 echo \\"Waiting until all Tessera nodes are running...\\"
 DOWN=true
@@ -169,9 +169,9 @@ done
 echo \\"All Tessera nodes started\\"
 
 echo \\"Starting Quorum nodes\\"
-PRIVATE_CONFIG=/current/working/dir/network/3-nodes-raft-tessera-bash/qdata/c1/tm.ipc nohup $BIN_GETH --datadir qdata/dd1 --nodiscover --rpc --rpccorsdomain=* --rpcvhosts=* --rpcaddr 0.0.0.0 --rpcapi admin,db,eth,debug,miner,net,shh,txpool,personal,web3,quorum,raft,quorumPermission --ws --wsaddr 0.0.0.0 --wsorigins=* --wsapi admin,db,eth,debug,miner,net,shh,txpool,personal,web3,quorum,raft,quorumPermission --emitcheckpoints --unlock 0 --password qdata/dd1/keystore/password.txt --allow-insecure-unlock --graphql --graphql.port 24000 --graphql.corsdomain=* --graphql.addr 0.0.0.0 --raft --raftport 50401 --permissioned --verbosity 5 --networkid 10 --rpcport 22000 --wsport 23000 --port 21000 2>>qdata/logs/1.log &
-PRIVATE_CONFIG=/current/working/dir/network/3-nodes-raft-tessera-bash/qdata/c2/tm.ipc nohup $BIN_GETH --datadir qdata/dd2 --nodiscover --rpc --rpccorsdomain=* --rpcvhosts=* --rpcaddr 0.0.0.0 --rpcapi admin,db,eth,debug,miner,net,shh,txpool,personal,web3,quorum,raft,quorumPermission --ws --wsaddr 0.0.0.0 --wsorigins=* --wsapi admin,db,eth,debug,miner,net,shh,txpool,personal,web3,quorum,raft,quorumPermission --emitcheckpoints --unlock 0 --password qdata/dd2/keystore/password.txt --allow-insecure-unlock --graphql --graphql.port 24001 --graphql.corsdomain=* --graphql.addr 0.0.0.0 --raft --raftport 50402 --permissioned --verbosity 5 --networkid 10 --rpcport 22001 --wsport 23001 --port 21001 2>>qdata/logs/2.log &
-PRIVATE_CONFIG=/current/working/dir/network/3-nodes-raft-tessera-bash/qdata/c3/tm.ipc nohup $BIN_GETH --datadir qdata/dd3 --nodiscover --rpc --rpccorsdomain=* --rpcvhosts=* --rpcaddr 0.0.0.0 --rpcapi admin,db,eth,debug,miner,net,shh,txpool,personal,web3,quorum,raft,quorumPermission --ws --wsaddr 0.0.0.0 --wsorigins=* --wsapi admin,db,eth,debug,miner,net,shh,txpool,personal,web3,quorum,raft,quorumPermission --emitcheckpoints --unlock 0 --password qdata/dd3/keystore/password.txt --allow-insecure-unlock --graphql --graphql.port 24002 --graphql.corsdomain=* --graphql.addr 0.0.0.0 --raft --raftport 50403 --permissioned --verbosity 5 --networkid 10 --rpcport 22002 --wsport 23002 --port 21002 2>>qdata/logs/3.log &
+PRIVATE_CONFIG='/current/working/dir/network/3-nodes-raft-tessera-bash/qdata/c1/tm.ipc' nohup \\"$BIN_GETH\\" --datadir qdata/dd1 --nodiscover --rpc --rpccorsdomain=* --rpcvhosts=* --rpcaddr 0.0.0.0 --rpcapi admin,db,eth,debug,miner,net,shh,txpool,personal,web3,quorum,raft,quorumPermission --ws --wsaddr 0.0.0.0 --wsorigins=* --wsapi admin,db,eth,debug,miner,net,shh,txpool,personal,web3,quorum,raft,quorumPermission --emitcheckpoints --unlock 0 --password qdata/dd1/keystore/password.txt --allow-insecure-unlock --graphql --graphql.port 24000 --graphql.corsdomain=* --graphql.addr 0.0.0.0 --raft --raftport 50401 --permissioned --verbosity 5 --networkid 10 --rpcport 22000 --wsport 23000 --port 21000 2>>qdata/logs/1.log &
+PRIVATE_CONFIG='/current/working/dir/network/3-nodes-raft-tessera-bash/qdata/c2/tm.ipc' nohup \\"$BIN_GETH\\" --datadir qdata/dd2 --nodiscover --rpc --rpccorsdomain=* --rpcvhosts=* --rpcaddr 0.0.0.0 --rpcapi admin,db,eth,debug,miner,net,shh,txpool,personal,web3,quorum,raft,quorumPermission --ws --wsaddr 0.0.0.0 --wsorigins=* --wsapi admin,db,eth,debug,miner,net,shh,txpool,personal,web3,quorum,raft,quorumPermission --emitcheckpoints --unlock 0 --password qdata/dd2/keystore/password.txt --allow-insecure-unlock --graphql --graphql.port 24001 --graphql.corsdomain=* --graphql.addr 0.0.0.0 --raft --raftport 50402 --permissioned --verbosity 5 --networkid 10 --rpcport 22001 --wsport 23001 --port 21001 2>>qdata/logs/2.log &
+PRIVATE_CONFIG='/current/working/dir/network/3-nodes-raft-tessera-bash/qdata/c3/tm.ipc' nohup \\"$BIN_GETH\\" --datadir qdata/dd3 --nodiscover --rpc --rpccorsdomain=* --rpcvhosts=* --rpcaddr 0.0.0.0 --rpcapi admin,db,eth,debug,miner,net,shh,txpool,personal,web3,quorum,raft,quorumPermission --ws --wsaddr 0.0.0.0 --wsorigins=* --wsapi admin,db,eth,debug,miner,net,shh,txpool,personal,web3,quorum,raft,quorumPermission --emitcheckpoints --unlock 0 --password qdata/dd3/keystore/password.txt --allow-insecure-unlock --graphql --graphql.port 24002 --graphql.corsdomain=* --graphql.addr 0.0.0.0 --raft --raftport 50403 --permissioned --verbosity 5 --networkid 10 --rpcport 22002 --wsport 23002 --port 21002 2>>qdata/logs/3.log &
 
 echo \\"Successfully started Quorum network.\\"
 echo \\"--------------------------------------------------------------------------------
@@ -194,13 +194,13 @@ exports[`creates 3nodes raft bash tessera cakeshop 1`] = `
 echo \\"
 Starting Quorum network...
 \\"
-BIN_GETH=/path/to/user/home/.quorum-wizard/bin/quorum/2.7.0/geth
-BIN_TESSERA=/path/to/user/home/.quorum-wizard/bin/tessera/0.10.6/tessera-app.jar
-BIN_CAKESHOP=/path/to/user/home/.quorum-wizard/bin/cakeshop/0.11.0/cakeshop.war
+BIN_GETH='/path/to/user/home/.quorum-wizard/bin/quorum/2.7.0/geth'
+BIN_TESSERA='/path/to/user/home/.quorum-wizard/bin/tessera/0.10.6/tessera-app.jar'
+BIN_CAKESHOP='/path/to/user/home/.quorum-wizard/bin/cakeshop/0.11.0/cakeshop.war'
 
-java  -Xms128M -Xmx128M -jar $BIN_TESSERA -configfile qdata/c1/tessera-config-09-1.json >> qdata/logs/tessera1.log 2>&1 &
-java  -Xms128M -Xmx128M -jar $BIN_TESSERA -configfile qdata/c2/tessera-config-09-2.json >> qdata/logs/tessera2.log 2>&1 &
-java  -Xms128M -Xmx128M -jar $BIN_TESSERA -configfile qdata/c3/tessera-config-09-3.json >> qdata/logs/tessera3.log 2>&1 &
+java  -Xms128M -Xmx128M -jar \\"$BIN_TESSERA\\" -configfile qdata/c1/tessera-config-09-1.json >> qdata/logs/tessera1.log 2>&1 &
+java  -Xms128M -Xmx128M -jar \\"$BIN_TESSERA\\" -configfile qdata/c2/tessera-config-09-2.json >> qdata/logs/tessera2.log 2>&1 &
+java  -Xms128M -Xmx128M -jar \\"$BIN_TESSERA\\" -configfile qdata/c3/tessera-config-09-3.json >> qdata/logs/tessera3.log 2>&1 &
 
 echo \\"Waiting until all Tessera nodes are running...\\"
 DOWN=true
@@ -247,11 +247,11 @@ done
 echo \\"All Tessera nodes started\\"
 
 echo \\"Starting Quorum nodes\\"
-PRIVATE_CONFIG=/current/working/dir/network/3-nodes-raft-tessera-bash/qdata/c1/tm.ipc nohup $BIN_GETH --datadir qdata/dd1 --nodiscover --rpc --rpccorsdomain=* --rpcvhosts=* --rpcaddr 0.0.0.0 --rpcapi admin,db,eth,debug,miner,net,shh,txpool,personal,web3,quorum,raft,quorumPermission --ws --wsaddr 0.0.0.0 --wsorigins=* --wsapi admin,db,eth,debug,miner,net,shh,txpool,personal,web3,quorum,raft,quorumPermission --emitcheckpoints --unlock 0 --password qdata/dd1/keystore/password.txt --allow-insecure-unlock --graphql --graphql.port 24000 --graphql.corsdomain=* --graphql.addr 0.0.0.0 --raft --raftport 50401 --permissioned --verbosity 5 --networkid 10 --rpcport 22000 --wsport 23000 --port 21000 2>>qdata/logs/1.log &
-PRIVATE_CONFIG=/current/working/dir/network/3-nodes-raft-tessera-bash/qdata/c2/tm.ipc nohup $BIN_GETH --datadir qdata/dd2 --nodiscover --rpc --rpccorsdomain=* --rpcvhosts=* --rpcaddr 0.0.0.0 --rpcapi admin,db,eth,debug,miner,net,shh,txpool,personal,web3,quorum,raft,quorumPermission --ws --wsaddr 0.0.0.0 --wsorigins=* --wsapi admin,db,eth,debug,miner,net,shh,txpool,personal,web3,quorum,raft,quorumPermission --emitcheckpoints --unlock 0 --password qdata/dd2/keystore/password.txt --allow-insecure-unlock --graphql --graphql.port 24001 --graphql.corsdomain=* --graphql.addr 0.0.0.0 --raft --raftport 50402 --permissioned --verbosity 5 --networkid 10 --rpcport 22001 --wsport 23001 --port 21001 2>>qdata/logs/2.log &
-PRIVATE_CONFIG=/current/working/dir/network/3-nodes-raft-tessera-bash/qdata/c3/tm.ipc nohup $BIN_GETH --datadir qdata/dd3 --nodiscover --rpc --rpccorsdomain=* --rpcvhosts=* --rpcaddr 0.0.0.0 --rpcapi admin,db,eth,debug,miner,net,shh,txpool,personal,web3,quorum,raft,quorumPermission --ws --wsaddr 0.0.0.0 --wsorigins=* --wsapi admin,db,eth,debug,miner,net,shh,txpool,personal,web3,quorum,raft,quorumPermission --emitcheckpoints --unlock 0 --password qdata/dd3/keystore/password.txt --allow-insecure-unlock --graphql --graphql.port 24002 --graphql.corsdomain=* --graphql.addr 0.0.0.0 --raft --raftport 50403 --permissioned --verbosity 5 --networkid 10 --rpcport 22002 --wsport 23002 --port 21002 2>>qdata/logs/3.log &
+PRIVATE_CONFIG='/current/working/dir/network/3-nodes-raft-tessera-bash/qdata/c1/tm.ipc' nohup \\"$BIN_GETH\\" --datadir qdata/dd1 --nodiscover --rpc --rpccorsdomain=* --rpcvhosts=* --rpcaddr 0.0.0.0 --rpcapi admin,db,eth,debug,miner,net,shh,txpool,personal,web3,quorum,raft,quorumPermission --ws --wsaddr 0.0.0.0 --wsorigins=* --wsapi admin,db,eth,debug,miner,net,shh,txpool,personal,web3,quorum,raft,quorumPermission --emitcheckpoints --unlock 0 --password qdata/dd1/keystore/password.txt --allow-insecure-unlock --graphql --graphql.port 24000 --graphql.corsdomain=* --graphql.addr 0.0.0.0 --raft --raftport 50401 --permissioned --verbosity 5 --networkid 10 --rpcport 22000 --wsport 23000 --port 21000 2>>qdata/logs/1.log &
+PRIVATE_CONFIG='/current/working/dir/network/3-nodes-raft-tessera-bash/qdata/c2/tm.ipc' nohup \\"$BIN_GETH\\" --datadir qdata/dd2 --nodiscover --rpc --rpccorsdomain=* --rpcvhosts=* --rpcaddr 0.0.0.0 --rpcapi admin,db,eth,debug,miner,net,shh,txpool,personal,web3,quorum,raft,quorumPermission --ws --wsaddr 0.0.0.0 --wsorigins=* --wsapi admin,db,eth,debug,miner,net,shh,txpool,personal,web3,quorum,raft,quorumPermission --emitcheckpoints --unlock 0 --password qdata/dd2/keystore/password.txt --allow-insecure-unlock --graphql --graphql.port 24001 --graphql.corsdomain=* --graphql.addr 0.0.0.0 --raft --raftport 50402 --permissioned --verbosity 5 --networkid 10 --rpcport 22001 --wsport 23001 --port 21001 2>>qdata/logs/2.log &
+PRIVATE_CONFIG='/current/working/dir/network/3-nodes-raft-tessera-bash/qdata/c3/tm.ipc' nohup \\"$BIN_GETH\\" --datadir qdata/dd3 --nodiscover --rpc --rpccorsdomain=* --rpcvhosts=* --rpcaddr 0.0.0.0 --rpcapi admin,db,eth,debug,miner,net,shh,txpool,personal,web3,quorum,raft,quorumPermission --ws --wsaddr 0.0.0.0 --wsorigins=* --wsapi admin,db,eth,debug,miner,net,shh,txpool,personal,web3,quorum,raft,quorumPermission --emitcheckpoints --unlock 0 --password qdata/dd3/keystore/password.txt --allow-insecure-unlock --graphql --graphql.port 24002 --graphql.corsdomain=* --graphql.addr 0.0.0.0 --raft --raftport 50403 --permissioned --verbosity 5 --networkid 10 --rpcport 22002 --wsport 23002 --port 21002 2>>qdata/logs/3.log &
 echo \\"Starting Cakeshop\\"
-java -Dcakeshop.config.dir=qdata/cakeshop -Dlogging.path=qdata/logs/cakeshop -jar $BIN_CAKESHOP > /dev/null 2>&1 &
+java -Dcakeshop.config.dir=qdata/cakeshop -Dlogging.path=qdata/logs/cakeshop -jar \\"$BIN_CAKESHOP\\" > /dev/null 2>&1 &
 
   DOWN=true
   k=10
@@ -298,12 +298,12 @@ exports[`creates 3nodes raft bash tessera custom 1`] = `
 echo \\"
 Starting Quorum network...
 \\"
-BIN_GETH=/path/to/user/home/.quorum-wizard/bin/quorum/2.7.0/geth
-BIN_TESSERA=/path/to/user/home/.quorum-wizard/bin/tessera/0.10.6/tessera-app.jar
+BIN_GETH='/path/to/user/home/.quorum-wizard/bin/quorum/2.7.0/geth'
+BIN_TESSERA='/path/to/user/home/.quorum-wizard/bin/tessera/0.10.6/tessera-app.jar'
 
-java  -Xms128M -Xmx128M -jar $BIN_TESSERA -configfile qdata/c1/tessera-config-09-1.json >> qdata/logs/tessera1.log 2>&1 &
-java  -Xms128M -Xmx128M -jar $BIN_TESSERA -configfile qdata/c2/tessera-config-09-2.json >> qdata/logs/tessera2.log 2>&1 &
-java  -Xms128M -Xmx128M -jar $BIN_TESSERA -configfile qdata/c3/tessera-config-09-3.json >> qdata/logs/tessera3.log 2>&1 &
+java  -Xms128M -Xmx128M -jar \\"$BIN_TESSERA\\" -configfile qdata/c1/tessera-config-09-1.json >> qdata/logs/tessera1.log 2>&1 &
+java  -Xms128M -Xmx128M -jar \\"$BIN_TESSERA\\" -configfile qdata/c2/tessera-config-09-2.json >> qdata/logs/tessera2.log 2>&1 &
+java  -Xms128M -Xmx128M -jar \\"$BIN_TESSERA\\" -configfile qdata/c3/tessera-config-09-3.json >> qdata/logs/tessera3.log 2>&1 &
 
 echo \\"Waiting until all Tessera nodes are running...\\"
 DOWN=true
@@ -350,9 +350,9 @@ done
 echo \\"All Tessera nodes started\\"
 
 echo \\"Starting Quorum nodes\\"
-PRIVATE_CONFIG=/current/working/dir/network/3-nodes-raft-tessera-bash/qdata/c1/tm.ipc nohup $BIN_GETH --datadir qdata/dd1 --nodiscover --rpc --rpccorsdomain=* --rpcvhosts=* --rpcaddr 0.0.0.0 --rpcapi admin,db,eth,debug,miner,net,shh,txpool,personal,web3,quorum,raft,quorumPermission --ws --wsaddr 0.0.0.0 --wsorigins=* --wsapi admin,db,eth,debug,miner,net,shh,txpool,personal,web3,quorum,raft,quorumPermission --emitcheckpoints --unlock 0 --password qdata/dd1/keystore/password.txt --allow-insecure-unlock --graphql --graphql.port 24000 --graphql.corsdomain=* --graphql.addr 0.0.0.0 --raft --raftport 50401 --permissioned --verbosity 5 --networkid 10 --rpcport 22000 --wsport 23000 --port 21000 2>>qdata/logs/1.log &
-PRIVATE_CONFIG=/current/working/dir/network/3-nodes-raft-tessera-bash/qdata/c2/tm.ipc nohup $BIN_GETH --datadir qdata/dd2 --nodiscover --rpc --rpccorsdomain=* --rpcvhosts=* --rpcaddr 0.0.0.0 --rpcapi admin,db,eth,debug,miner,net,shh,txpool,personal,web3,quorum,raft,quorumPermission --ws --wsaddr 0.0.0.0 --wsorigins=* --wsapi admin,db,eth,debug,miner,net,shh,txpool,personal,web3,quorum,raft,quorumPermission --emitcheckpoints --unlock 0 --password qdata/dd2/keystore/password.txt --allow-insecure-unlock --graphql --graphql.port 24001 --graphql.corsdomain=* --graphql.addr 0.0.0.0 --raft --raftport 50402 --permissioned --verbosity 5 --networkid 10 --rpcport 22001 --wsport 23001 --port 21001 2>>qdata/logs/2.log &
-PRIVATE_CONFIG=/current/working/dir/network/3-nodes-raft-tessera-bash/qdata/c3/tm.ipc nohup $BIN_GETH --datadir qdata/dd3 --nodiscover --rpc --rpccorsdomain=* --rpcvhosts=* --rpcaddr 0.0.0.0 --rpcapi admin,db,eth,debug,miner,net,shh,txpool,personal,web3,quorum,raft,quorumPermission --ws --wsaddr 0.0.0.0 --wsorigins=* --wsapi admin,db,eth,debug,miner,net,shh,txpool,personal,web3,quorum,raft,quorumPermission --emitcheckpoints --unlock 0 --password qdata/dd3/keystore/password.txt --allow-insecure-unlock --graphql --graphql.port 24002 --graphql.corsdomain=* --graphql.addr 0.0.0.0 --raft --raftport 50403 --permissioned --verbosity 5 --networkid 10 --rpcport 22002 --wsport 23002 --port 21002 2>>qdata/logs/3.log &
+PRIVATE_CONFIG='/current/working/dir/network/3-nodes-raft-tessera-bash/qdata/c1/tm.ipc' nohup \\"$BIN_GETH\\" --datadir qdata/dd1 --nodiscover --rpc --rpccorsdomain=* --rpcvhosts=* --rpcaddr 0.0.0.0 --rpcapi admin,db,eth,debug,miner,net,shh,txpool,personal,web3,quorum,raft,quorumPermission --ws --wsaddr 0.0.0.0 --wsorigins=* --wsapi admin,db,eth,debug,miner,net,shh,txpool,personal,web3,quorum,raft,quorumPermission --emitcheckpoints --unlock 0 --password qdata/dd1/keystore/password.txt --allow-insecure-unlock --graphql --graphql.port 24000 --graphql.corsdomain=* --graphql.addr 0.0.0.0 --raft --raftport 50401 --permissioned --verbosity 5 --networkid 10 --rpcport 22000 --wsport 23000 --port 21000 2>>qdata/logs/1.log &
+PRIVATE_CONFIG='/current/working/dir/network/3-nodes-raft-tessera-bash/qdata/c2/tm.ipc' nohup \\"$BIN_GETH\\" --datadir qdata/dd2 --nodiscover --rpc --rpccorsdomain=* --rpcvhosts=* --rpcaddr 0.0.0.0 --rpcapi admin,db,eth,debug,miner,net,shh,txpool,personal,web3,quorum,raft,quorumPermission --ws --wsaddr 0.0.0.0 --wsorigins=* --wsapi admin,db,eth,debug,miner,net,shh,txpool,personal,web3,quorum,raft,quorumPermission --emitcheckpoints --unlock 0 --password qdata/dd2/keystore/password.txt --allow-insecure-unlock --graphql --graphql.port 24001 --graphql.corsdomain=* --graphql.addr 0.0.0.0 --raft --raftport 50402 --permissioned --verbosity 5 --networkid 10 --rpcport 22001 --wsport 23001 --port 21001 2>>qdata/logs/2.log &
+PRIVATE_CONFIG='/current/working/dir/network/3-nodes-raft-tessera-bash/qdata/c3/tm.ipc' nohup \\"$BIN_GETH\\" --datadir qdata/dd3 --nodiscover --rpc --rpccorsdomain=* --rpcvhosts=* --rpcaddr 0.0.0.0 --rpcapi admin,db,eth,debug,miner,net,shh,txpool,personal,web3,quorum,raft,quorumPermission --ws --wsaddr 0.0.0.0 --wsorigins=* --wsapi admin,db,eth,debug,miner,net,shh,txpool,personal,web3,quorum,raft,quorumPermission --emitcheckpoints --unlock 0 --password qdata/dd3/keystore/password.txt --allow-insecure-unlock --graphql --graphql.port 24002 --graphql.corsdomain=* --graphql.addr 0.0.0.0 --raft --raftport 50403 --permissioned --verbosity 5 --networkid 10 --rpcport 22002 --wsport 23002 --port 21002 2>>qdata/logs/3.log &
 
 echo \\"Successfully started Quorum network.\\"
 echo \\"--------------------------------------------------------------------------------
@@ -375,13 +375,13 @@ exports[`creates quickstart config 1`] = `
 echo \\"
 Starting Quorum network...
 \\"
-BIN_GETH=/path/to/user/home/.quorum-wizard/bin/quorum/2.7.0/geth
-BIN_TESSERA=/path/to/user/home/.quorum-wizard/bin/tessera/0.10.6/tessera-app.jar
-BIN_CAKESHOP=/path/to/user/home/.quorum-wizard/bin/cakeshop/0.11.0/cakeshop.war
+BIN_GETH='/path/to/user/home/.quorum-wizard/bin/quorum/2.7.0/geth'
+BIN_TESSERA='/path/to/user/home/.quorum-wizard/bin/tessera/0.10.6/tessera-app.jar'
+BIN_CAKESHOP='/path/to/user/home/.quorum-wizard/bin/cakeshop/0.11.0/cakeshop.war'
 
-java  -Xms128M -Xmx128M -jar $BIN_TESSERA -configfile qdata/c1/tessera-config-09-1.json >> qdata/logs/tessera1.log 2>&1 &
-java  -Xms128M -Xmx128M -jar $BIN_TESSERA -configfile qdata/c2/tessera-config-09-2.json >> qdata/logs/tessera2.log 2>&1 &
-java  -Xms128M -Xmx128M -jar $BIN_TESSERA -configfile qdata/c3/tessera-config-09-3.json >> qdata/logs/tessera3.log 2>&1 &
+java  -Xms128M -Xmx128M -jar \\"$BIN_TESSERA\\" -configfile qdata/c1/tessera-config-09-1.json >> qdata/logs/tessera1.log 2>&1 &
+java  -Xms128M -Xmx128M -jar \\"$BIN_TESSERA\\" -configfile qdata/c2/tessera-config-09-2.json >> qdata/logs/tessera2.log 2>&1 &
+java  -Xms128M -Xmx128M -jar \\"$BIN_TESSERA\\" -configfile qdata/c3/tessera-config-09-3.json >> qdata/logs/tessera3.log 2>&1 &
 
 echo \\"Waiting until all Tessera nodes are running...\\"
 DOWN=true
@@ -428,11 +428,11 @@ done
 echo \\"All Tessera nodes started\\"
 
 echo \\"Starting Quorum nodes\\"
-PRIVATE_CONFIG=/current/working/dir/network/3-nodes-raft-tessera-bash/qdata/c1/tm.ipc nohup $BIN_GETH --datadir qdata/dd1 --nodiscover --rpc --rpccorsdomain=* --rpcvhosts=* --rpcaddr 0.0.0.0 --rpcapi admin,db,eth,debug,miner,net,shh,txpool,personal,web3,quorum,raft,quorumPermission --ws --wsaddr 0.0.0.0 --wsorigins=* --wsapi admin,db,eth,debug,miner,net,shh,txpool,personal,web3,quorum,raft,quorumPermission --emitcheckpoints --unlock 0 --password qdata/dd1/keystore/password.txt --allow-insecure-unlock --graphql --graphql.port 24000 --graphql.corsdomain=* --graphql.addr 0.0.0.0 --raft --raftport 50401 --permissioned --verbosity 5 --networkid 10 --rpcport 22000 --wsport 23000 --port 21000 2>>qdata/logs/1.log &
-PRIVATE_CONFIG=/current/working/dir/network/3-nodes-raft-tessera-bash/qdata/c2/tm.ipc nohup $BIN_GETH --datadir qdata/dd2 --nodiscover --rpc --rpccorsdomain=* --rpcvhosts=* --rpcaddr 0.0.0.0 --rpcapi admin,db,eth,debug,miner,net,shh,txpool,personal,web3,quorum,raft,quorumPermission --ws --wsaddr 0.0.0.0 --wsorigins=* --wsapi admin,db,eth,debug,miner,net,shh,txpool,personal,web3,quorum,raft,quorumPermission --emitcheckpoints --unlock 0 --password qdata/dd2/keystore/password.txt --allow-insecure-unlock --graphql --graphql.port 24001 --graphql.corsdomain=* --graphql.addr 0.0.0.0 --raft --raftport 50402 --permissioned --verbosity 5 --networkid 10 --rpcport 22001 --wsport 23001 --port 21001 2>>qdata/logs/2.log &
-PRIVATE_CONFIG=/current/working/dir/network/3-nodes-raft-tessera-bash/qdata/c3/tm.ipc nohup $BIN_GETH --datadir qdata/dd3 --nodiscover --rpc --rpccorsdomain=* --rpcvhosts=* --rpcaddr 0.0.0.0 --rpcapi admin,db,eth,debug,miner,net,shh,txpool,personal,web3,quorum,raft,quorumPermission --ws --wsaddr 0.0.0.0 --wsorigins=* --wsapi admin,db,eth,debug,miner,net,shh,txpool,personal,web3,quorum,raft,quorumPermission --emitcheckpoints --unlock 0 --password qdata/dd3/keystore/password.txt --allow-insecure-unlock --graphql --graphql.port 24002 --graphql.corsdomain=* --graphql.addr 0.0.0.0 --raft --raftport 50403 --permissioned --verbosity 5 --networkid 10 --rpcport 22002 --wsport 23002 --port 21002 2>>qdata/logs/3.log &
+PRIVATE_CONFIG='/current/working/dir/network/3-nodes-raft-tessera-bash/qdata/c1/tm.ipc' nohup \\"$BIN_GETH\\" --datadir qdata/dd1 --nodiscover --rpc --rpccorsdomain=* --rpcvhosts=* --rpcaddr 0.0.0.0 --rpcapi admin,db,eth,debug,miner,net,shh,txpool,personal,web3,quorum,raft,quorumPermission --ws --wsaddr 0.0.0.0 --wsorigins=* --wsapi admin,db,eth,debug,miner,net,shh,txpool,personal,web3,quorum,raft,quorumPermission --emitcheckpoints --unlock 0 --password qdata/dd1/keystore/password.txt --allow-insecure-unlock --graphql --graphql.port 24000 --graphql.corsdomain=* --graphql.addr 0.0.0.0 --raft --raftport 50401 --permissioned --verbosity 5 --networkid 10 --rpcport 22000 --wsport 23000 --port 21000 2>>qdata/logs/1.log &
+PRIVATE_CONFIG='/current/working/dir/network/3-nodes-raft-tessera-bash/qdata/c2/tm.ipc' nohup \\"$BIN_GETH\\" --datadir qdata/dd2 --nodiscover --rpc --rpccorsdomain=* --rpcvhosts=* --rpcaddr 0.0.0.0 --rpcapi admin,db,eth,debug,miner,net,shh,txpool,personal,web3,quorum,raft,quorumPermission --ws --wsaddr 0.0.0.0 --wsorigins=* --wsapi admin,db,eth,debug,miner,net,shh,txpool,personal,web3,quorum,raft,quorumPermission --emitcheckpoints --unlock 0 --password qdata/dd2/keystore/password.txt --allow-insecure-unlock --graphql --graphql.port 24001 --graphql.corsdomain=* --graphql.addr 0.0.0.0 --raft --raftport 50402 --permissioned --verbosity 5 --networkid 10 --rpcport 22001 --wsport 23001 --port 21001 2>>qdata/logs/2.log &
+PRIVATE_CONFIG='/current/working/dir/network/3-nodes-raft-tessera-bash/qdata/c3/tm.ipc' nohup \\"$BIN_GETH\\" --datadir qdata/dd3 --nodiscover --rpc --rpccorsdomain=* --rpcvhosts=* --rpcaddr 0.0.0.0 --rpcapi admin,db,eth,debug,miner,net,shh,txpool,personal,web3,quorum,raft,quorumPermission --ws --wsaddr 0.0.0.0 --wsorigins=* --wsapi admin,db,eth,debug,miner,net,shh,txpool,personal,web3,quorum,raft,quorumPermission --emitcheckpoints --unlock 0 --password qdata/dd3/keystore/password.txt --allow-insecure-unlock --graphql --graphql.port 24002 --graphql.corsdomain=* --graphql.addr 0.0.0.0 --raft --raftport 50403 --permissioned --verbosity 5 --networkid 10 --rpcport 22002 --wsport 23002 --port 21002 2>>qdata/logs/3.log &
 echo \\"Starting Cakeshop\\"
-java -Dcakeshop.config.dir=qdata/cakeshop -Dlogging.path=qdata/logs/cakeshop -jar $BIN_CAKESHOP > /dev/null 2>&1 &
+java -Dcakeshop.config.dir=qdata/cakeshop -Dlogging.path=qdata/logs/cakeshop -jar \\"$BIN_CAKESHOP\\" > /dev/null 2>&1 &
 
   DOWN=true
   k=10
@@ -479,13 +479,13 @@ exports[`creates quickstart start script without insecure unlock flag on quorum 
 echo \\"
 Starting Quorum network...
 \\"
-BIN_GETH=/path/to/user/home/.quorum-wizard/bin/quorum/2.5.0/geth
-BIN_TESSERA=/path/to/user/home/.quorum-wizard/bin/tessera/0.10.6/tessera-app.jar
-BIN_CAKESHOP=/path/to/user/home/.quorum-wizard/bin/cakeshop/0.11.0/cakeshop.war
+BIN_GETH='/path/to/user/home/.quorum-wizard/bin/quorum/2.5.0/geth'
+BIN_TESSERA='/path/to/user/home/.quorum-wizard/bin/tessera/0.10.6/tessera-app.jar'
+BIN_CAKESHOP='/path/to/user/home/.quorum-wizard/bin/cakeshop/0.11.0/cakeshop.war'
 
-java  -Xms128M -Xmx128M -jar $BIN_TESSERA -configfile qdata/c1/tessera-config-09-1.json >> qdata/logs/tessera1.log 2>&1 &
-java  -Xms128M -Xmx128M -jar $BIN_TESSERA -configfile qdata/c2/tessera-config-09-2.json >> qdata/logs/tessera2.log 2>&1 &
-java  -Xms128M -Xmx128M -jar $BIN_TESSERA -configfile qdata/c3/tessera-config-09-3.json >> qdata/logs/tessera3.log 2>&1 &
+java  -Xms128M -Xmx128M -jar \\"$BIN_TESSERA\\" -configfile qdata/c1/tessera-config-09-1.json >> qdata/logs/tessera1.log 2>&1 &
+java  -Xms128M -Xmx128M -jar \\"$BIN_TESSERA\\" -configfile qdata/c2/tessera-config-09-2.json >> qdata/logs/tessera2.log 2>&1 &
+java  -Xms128M -Xmx128M -jar \\"$BIN_TESSERA\\" -configfile qdata/c3/tessera-config-09-3.json >> qdata/logs/tessera3.log 2>&1 &
 
 echo \\"Waiting until all Tessera nodes are running...\\"
 DOWN=true
@@ -532,11 +532,11 @@ done
 echo \\"All Tessera nodes started\\"
 
 echo \\"Starting Quorum nodes\\"
-PRIVATE_CONFIG=/current/working/dir/network/3-nodes-raft-tessera-bash/qdata/c1/tm.ipc nohup $BIN_GETH --datadir qdata/dd1 --nodiscover --rpc --rpccorsdomain=* --rpcvhosts=* --rpcaddr 0.0.0.0 --rpcapi admin,db,eth,debug,miner,net,shh,txpool,personal,web3,quorum,raft,quorumPermission --ws --wsaddr 0.0.0.0 --wsorigins=* --wsapi admin,db,eth,debug,miner,net,shh,txpool,personal,web3,quorum,raft,quorumPermission --emitcheckpoints --unlock 0 --password qdata/dd1/keystore/password.txt  --raft --raftport 50401 --permissioned --verbosity 5 --networkid 10 --rpcport 22000 --wsport 23000 --port 21000 2>>qdata/logs/1.log &
-PRIVATE_CONFIG=/current/working/dir/network/3-nodes-raft-tessera-bash/qdata/c2/tm.ipc nohup $BIN_GETH --datadir qdata/dd2 --nodiscover --rpc --rpccorsdomain=* --rpcvhosts=* --rpcaddr 0.0.0.0 --rpcapi admin,db,eth,debug,miner,net,shh,txpool,personal,web3,quorum,raft,quorumPermission --ws --wsaddr 0.0.0.0 --wsorigins=* --wsapi admin,db,eth,debug,miner,net,shh,txpool,personal,web3,quorum,raft,quorumPermission --emitcheckpoints --unlock 0 --password qdata/dd2/keystore/password.txt  --raft --raftport 50402 --permissioned --verbosity 5 --networkid 10 --rpcport 22001 --wsport 23001 --port 21001 2>>qdata/logs/2.log &
-PRIVATE_CONFIG=/current/working/dir/network/3-nodes-raft-tessera-bash/qdata/c3/tm.ipc nohup $BIN_GETH --datadir qdata/dd3 --nodiscover --rpc --rpccorsdomain=* --rpcvhosts=* --rpcaddr 0.0.0.0 --rpcapi admin,db,eth,debug,miner,net,shh,txpool,personal,web3,quorum,raft,quorumPermission --ws --wsaddr 0.0.0.0 --wsorigins=* --wsapi admin,db,eth,debug,miner,net,shh,txpool,personal,web3,quorum,raft,quorumPermission --emitcheckpoints --unlock 0 --password qdata/dd3/keystore/password.txt  --raft --raftport 50403 --permissioned --verbosity 5 --networkid 10 --rpcport 22002 --wsport 23002 --port 21002 2>>qdata/logs/3.log &
+PRIVATE_CONFIG='/current/working/dir/network/3-nodes-raft-tessera-bash/qdata/c1/tm.ipc' nohup \\"$BIN_GETH\\" --datadir qdata/dd1 --nodiscover --rpc --rpccorsdomain=* --rpcvhosts=* --rpcaddr 0.0.0.0 --rpcapi admin,db,eth,debug,miner,net,shh,txpool,personal,web3,quorum,raft,quorumPermission --ws --wsaddr 0.0.0.0 --wsorigins=* --wsapi admin,db,eth,debug,miner,net,shh,txpool,personal,web3,quorum,raft,quorumPermission --emitcheckpoints --unlock 0 --password qdata/dd1/keystore/password.txt  --raft --raftport 50401 --permissioned --verbosity 5 --networkid 10 --rpcport 22000 --wsport 23000 --port 21000 2>>qdata/logs/1.log &
+PRIVATE_CONFIG='/current/working/dir/network/3-nodes-raft-tessera-bash/qdata/c2/tm.ipc' nohup \\"$BIN_GETH\\" --datadir qdata/dd2 --nodiscover --rpc --rpccorsdomain=* --rpcvhosts=* --rpcaddr 0.0.0.0 --rpcapi admin,db,eth,debug,miner,net,shh,txpool,personal,web3,quorum,raft,quorumPermission --ws --wsaddr 0.0.0.0 --wsorigins=* --wsapi admin,db,eth,debug,miner,net,shh,txpool,personal,web3,quorum,raft,quorumPermission --emitcheckpoints --unlock 0 --password qdata/dd2/keystore/password.txt  --raft --raftport 50402 --permissioned --verbosity 5 --networkid 10 --rpcport 22001 --wsport 23001 --port 21001 2>>qdata/logs/2.log &
+PRIVATE_CONFIG='/current/working/dir/network/3-nodes-raft-tessera-bash/qdata/c3/tm.ipc' nohup \\"$BIN_GETH\\" --datadir qdata/dd3 --nodiscover --rpc --rpccorsdomain=* --rpcvhosts=* --rpcaddr 0.0.0.0 --rpcapi admin,db,eth,debug,miner,net,shh,txpool,personal,web3,quorum,raft,quorumPermission --ws --wsaddr 0.0.0.0 --wsorigins=* --wsapi admin,db,eth,debug,miner,net,shh,txpool,personal,web3,quorum,raft,quorumPermission --emitcheckpoints --unlock 0 --password qdata/dd3/keystore/password.txt  --raft --raftport 50403 --permissioned --verbosity 5 --networkid 10 --rpcport 22002 --wsport 23002 --port 21002 2>>qdata/logs/3.log &
 echo \\"Starting Cakeshop\\"
-java -Dcakeshop.config.dir=qdata/cakeshop -Dlogging.path=qdata/logs/cakeshop -jar $BIN_CAKESHOP > /dev/null 2>&1 &
+java -Dcakeshop.config.dir=qdata/cakeshop -Dlogging.path=qdata/logs/cakeshop -jar \\"$BIN_CAKESHOP\\" > /dev/null 2>&1 &
 
   DOWN=true
   k=10

--- a/src/generators/bashHelper.js
+++ b/src/generators/bashHelper.js
@@ -15,7 +15,7 @@ export async function initBash(config) {
     const nodeNumber = i + 1
     const quorumDir = joinPath('qdata', `dd${nodeNumber}`)
     const genesisLocation = joinPath(quorumDir, 'genesis.json')
-    const initCommand = `cd ${networkPath} && ${pathToQuorumBinary(config.network.quorumVersion)} --datadir ${quorumDir} init ${genesisLocation} 2>&1`
+    const initCommand = `cd '${networkPath}' && '${pathToQuorumBinary(config.network.quorumVersion)}' --datadir '${quorumDir}' init '${genesisLocation}' 2>&1`
     initCommands.push(initCommand)
   })
 
@@ -99,7 +99,7 @@ export function createGethStartCommand(config, node, passwordDestination, nodeNu
     ? `--raft --raftport ${raftPort}`
     : '--istanbul.blockperiod 5 --syncmode full --mine --minerthreads 1'
 
-  return `PRIVATE_CONFIG=${tmIpcPath} nohup $BIN_GETH --datadir qdata/dd${nodeNumber} ${args} ${consensusArgs} --permissioned --verbosity ${verbosity} --networkid ${networkId} --rpcport ${rpcPort} --wsport ${wsPort} --port ${devP2pPort} 2>>qdata/logs/${nodeNumber}.log &`
+  return `PRIVATE_CONFIG='${tmIpcPath}' nohup "$BIN_GETH" --datadir qdata/dd${nodeNumber} ${args} ${consensusArgs} --permissioned --verbosity ${verbosity} --networkid ${networkId} --rpcport ${rpcPort} --wsport ${wsPort} --port ${devP2pPort} 2>>qdata/logs/${nodeNumber}.log &`
 }
 
 export function createTesseraStartCommand(config, node, nodeNumber, tmDir, logDir) {
@@ -111,7 +111,7 @@ export function createTesseraStartCommand(config, node, nodeNumber, tmDir, logDi
   }
 
   const MEMORY = '-Xms128M -Xmx128M'
-  const CMD = `java ${DEBUG} ${MEMORY} -jar $BIN_TESSERA -configfile ${tmDir}/tessera-config-09-${nodeNumber}.json >> ${logDir}/tessera${nodeNumber}.log 2>&1 &`
+  const CMD = `java ${DEBUG} ${MEMORY} -jar "$BIN_TESSERA" -configfile ${tmDir}/tessera-config-09-${nodeNumber}.json >> ${logDir}/tessera${nodeNumber}.log 2>&1 &`
   return CMD
 }
 

--- a/src/generators/cakeshopHelper.js
+++ b/src/generators/cakeshopHelper.js
@@ -38,7 +38,7 @@ export function generateCakeshopScript(config) {
     return ''
   }
   const jvmParams = '-Dcakeshop.config.dir=qdata/cakeshop -Dlogging.path=qdata/logs/cakeshop'
-  const startCommand = `java ${jvmParams} -jar $BIN_CAKESHOP > /dev/null 2>&1 &`
+  const startCommand = `java ${jvmParams} -jar "$BIN_CAKESHOP" > /dev/null 2>&1 &`
   return [
     'echo "Starting Cakeshop"',
     startCommand,

--- a/src/generators/keyGen.js
+++ b/src/generators/keyGen.js
@@ -30,14 +30,14 @@ export async function generateKeys(config, keyPath) {
 }
 
 function doExec(keyDir, config) {
-  let cmd = `cd ${keyDir} && ${pathToQuorumBinary(config.network.quorumVersion)} account new --keystore ${keyDir} --password password.txt 2>&1
-  ${pathToBootnode()} -genkey=nodekey
-  ${pathToBootnode()} --nodekey=nodekey --writeaddress > enode
+  let cmd = `cd '${keyDir}' && '${pathToQuorumBinary(config.network.quorumVersion)}' account new --keystore '${keyDir}' --password password.txt 2>&1
+  '${pathToBootnode()}' -genkey=nodekey
+  '${pathToBootnode()}' --nodekey=nodekey --writeaddress > enode
   find . -type f -name 'UTC*' -execdir mv {} acctkeyfile.json ';'
   `
   if (isTessera(config.network.transactionManager)) {
     // blank password for now using `< /dev/null` to automatically answer password prompts
-    cmd += `java -jar ${pathToTesseraJar(config.network.transactionManager)} -keygen -filename tm < /dev/null`
+    cmd += `java -jar '${pathToTesseraJar(config.network.transactionManager)}' -keygen -filename tm < /dev/null`
   }
 
   return execute(cmd)

--- a/src/generators/keyGen.test.js
+++ b/src/generators/keyGen.test.js
@@ -38,9 +38,9 @@ describe('generates keys', () => {
     await generateKeys(config, joinPath(createNetPath(config), 'keyPath'))
     const keyNum = config.nodes.length
 
-    const expected = `cd ${joinPath(createNetPath(config), 'keyPath')}/key${keyNum} && quorumPath account new --keystore ${joinPath(createNetPath(config), 'keyPath')}/key${keyNum} --password password.txt 2>&1
-  bootnodePath -genkey=nodekey
-  bootnodePath --nodekey=nodekey --writeaddress > enode
+    const expected = `cd '${joinPath(createNetPath(config), 'keyPath')}/key${keyNum}' && 'quorumPath' account new --keystore '${joinPath(createNetPath(config), 'keyPath')}/key${keyNum}' --password password.txt 2>&1
+  'bootnodePath' -genkey=nodekey
+  'bootnodePath' --nodekey=nodekey --writeaddress > enode
   find . -type f -name 'UTC*' -execdir mv {} acctkeyfile.json ';'
   `
     expect(createFolder).toBeCalledWith(joinPath(createNetPath(config), 'keyPath', `key${keyNum}`), true)
@@ -62,11 +62,11 @@ describe('generates keys', () => {
     await generateKeys(config, joinPath(createNetPath(config), 'keyPath'))
     const keyNum = config.nodes.length
 
-    const withTessera = `cd ${joinPath(createNetPath(config), 'keyPath')}/key${keyNum} && quorumPath account new --keystore ${joinPath(createNetPath(config), 'keyPath')}/key${keyNum} --password password.txt 2>&1
-  bootnodePath -genkey=nodekey
-  bootnodePath --nodekey=nodekey --writeaddress > enode
+    const withTessera = `cd '${joinPath(createNetPath(config), 'keyPath')}/key${keyNum}' && 'quorumPath' account new --keystore '${joinPath(createNetPath(config), 'keyPath')}/key${keyNum}' --password password.txt 2>&1
+  'bootnodePath' -genkey=nodekey
+  'bootnodePath' --nodekey=nodekey --writeaddress > enode
   find . -type f -name 'UTC*' -execdir mv {} acctkeyfile.json ';'
-  java -jar tesseraPath -keygen -filename tm < /dev/null`
+  java -jar 'tesseraPath' -keygen -filename tm < /dev/null`
 
     expect(createFolder).toBeCalledWith(joinPath(createNetPath(config), 'keyPath', `key${keyNum}`), true)
     expect(writeFile).toBeCalledWith(joinPath(createNetPath(config), 'keyPath', `key${keyNum}`, 'password.txt'), '')

--- a/src/generators/networkCreator.js
+++ b/src/generators/networkCreator.js
@@ -60,10 +60,10 @@ export function generateResourcesRemote(config) {
   const qubernetesImage = `${getDockerRegistry()}quorumengineering/qubernetes:${LATEST_QUBERNETES}`
   const outPath = joinPath(networkPath, 'out')
   const dockerCommands = [
-    `cd ${networkPath}`,
+    `cd '${networkPath}'`,
     `docker pull ${qubernetesImage}`,
     // docker volumes using C:\folder\ style paths cause problems, convert to /c/folder/ on windows
-    `docker run --rm -v ${unixifyPath(qubernetesYamlPath)}:/qubernetes/qubernetes.yaml -v ${unixifyPath(outPath)}:/qubernetes/out ${qubernetesImage} /bin/bash -c "${generateScript} ${qubeScript} ${fixPermissionsScript}"`,
+    `docker run --rm -v '${unixifyPath(qubernetesYamlPath)}':/qubernetes/qubernetes.yaml -v '${unixifyPath(outPath)}':/qubernetes/out ${qubernetesImage} /bin/bash -c "${generateScript} ${qubeScript} ${fixPermissionsScript}"`,
   ]
 
   try {

--- a/src/generators/scripts/attach.js
+++ b/src/generators/scripts/attach.js
@@ -26,7 +26,7 @@ function attachCommand(config) {
 
 export function attachCommandBash(config) {
   return `${setEnvironmentCommand(config)}
-$BIN_GETH attach qdata/dd$1/geth.ipc`
+"$BIN_GETH" attach qdata/dd$1/geth.ipc`
 }
 
 function attachCommandDockerWindows() {

--- a/src/generators/scripts/runscript.js
+++ b/src/generators/scripts/runscript.js
@@ -27,7 +27,7 @@ function runScript(config) {
 
 export function runscriptCommandBash(config) {
   return `${setEnvironmentCommand(config)}
-$BIN_GETH --exec "loadScript(\\"$1\\")" attach qdata/dd1/geth.ipc`
+"$BIN_GETH" --exec "loadScript(\\"$1\\")" attach qdata/dd1/geth.ipc`
 }
 
 function runScriptCommandDockerWindows() {

--- a/src/generators/scripts/stop.js
+++ b/src/generators/scripts/stop.js
@@ -22,21 +22,13 @@ export function stopScriptBash() {
 killall -INT geth
 killall constellation-node
 
-if [ "\`jps | grep tessera\`" != "" ]
+if [ "\`ps -ef | grep tessera-app.jar | grep -v grep\`" != "" ]
 then
-    jps | grep tessera | cut -d " " -f1 | xargs kill
+    ps -ef | grep tessera-app.jar | grep -v grep | awk '{print $2}' | xargs kill
 else
     echo "tessera: no process found"
 fi
 
-if [ "\`jps | grep enclave\`" != "" ]
-then
-    jps | grep enclave | cut -d " " -f1 | xargs kill
-else
-    echo "enclave: no process found"
-fi
-
-# there is a bug in jps where it won't show the full filename for war files, using ps + grep instead
 if [ "\`ps -ef | grep cakeshop.war | grep -v grep\`" != "" ]
 then
     ps -ef | grep cakeshop.war | grep -v grep | awk '{print $2}' | xargs kill

--- a/src/generators/scripts/utils.js
+++ b/src/generators/scripts/utils.js
@@ -4,12 +4,12 @@ import { isWin32 } from '../../utils/execUtils'
 
 export function setEnvironmentCommand(config) {
   const lines = []
-  lines.push(`BIN_GETH=${pathToQuorumBinary(config.network.quorumVersion)}`)
+  lines.push(`BIN_GETH='${pathToQuorumBinary(config.network.quorumVersion)}'`)
   if (isTessera(config.network.transactionManager)) {
-    lines.push(`BIN_TESSERA=${pathToTesseraJar(config.network.transactionManager)}`)
+    lines.push(`BIN_TESSERA='${pathToTesseraJar(config.network.transactionManager)}'`)
   }
   if (isCakeshop(config.network.cakeshop)) {
-    lines.push(`BIN_CAKESHOP=${pathToCakeshop(config.network.cakeshop)}`)
+    lines.push(`BIN_CAKESHOP='${pathToCakeshop(config.network.cakeshop)}'`)
   }
   lines.push('')
   return lines.join('\n')

--- a/src/model/TesseraConfig.js
+++ b/src/model/TesseraConfig.js
@@ -22,7 +22,8 @@ export function createConfig(DDIR, i, ip, serverPortThirdParty, serverPortP2P, p
       {
         app: 'Q2T',
         enabled: true,
-        serverAddress: `unix:${DDIR}/tm.ipc`,
+        // Tessera uses URI.parse() for this, url encode any spaces in the path
+        serverAddress: `unix:${DDIR.replace(/\s/g, '%20')}/tm.ipc`,
         communicationType: 'REST',
       },
       {


### PR DESCRIPTION
fixes #109 

- Wraps paths that include the full network path in single quotes to handle directories with spaces in the name
- Wraps binary paths and env variable refs in quotes too just in case the path to .quorum-wizard in the home directory has spaces
- Url Encodes spaces in tessera config, otherwise the call to URI.parse() for the unix socket path in Tessera fails